### PR TITLE
Add "disclaimer" data file

### DIFF
--- a/fortune-mod/CMakeLists.txt
+++ b/fortune-mod/CMakeLists.txt
@@ -185,6 +185,7 @@ SET (COOKIES
     computers
     cookie
     definitions
+    disclaimer
     drugs
     education
     ethnic

--- a/fortune-mod/cookie-files
+++ b/fortune-mod/cookie-files
@@ -30,6 +30,8 @@ cookie		: Cookie file from Karl Lehenbauer's postings to alt.sources
 definitions	: It ought to be all the 'definitions,' but what it really
 		  is, is all the definitions that have a first line ending
 		  with a colon.
+disclaimer	: Disclaimer texts found on products and advertisements.
+		  Work well after corporate mandated login banners.
 drugs		: Alcohol and cigarettes, mostly.  Legal chemicals.
 education	: Schools, teachers, and scholarship, mostly not complimentary.
 ethnic		: Jokes that are about groups of people, but aren't making

--- a/fortune-mod/datfiles/disclaimer
+++ b/fortune-mod/datfiles/disclaimer
@@ -1,0 +1,580 @@
+15% gratuity added for parties over 8.
+%
+If you suspect that this message may have been intercepted or amended,
+please call the sender.
+%
+30 day money back guarantee minus shipping, 10% restocking charge, and 7%
+cancellation charge.
+%
+98% lean.
+%
+All rights reserved.
+%
+All celebrity voices impersonated.
+%
+All international orders must be accompanied by payment in U. S. funds.
+%
+All models over 18 years of age.
+%
+All names listed are proprietary trademarks of their respective corporations.
+%
+Allow 6 to 8 weeks for delivery.
+%
+Always wear your seat belt.
+%
+Any reproduction or redistribution of the Software not in accordance with the
+License Agreement is expressly prohibited by law, and may result in severe
+civil and criminal penalties.
+%
+Any resemblance to real persons, living or dead, is purely coincidental.
+%
+Apply only to affected area.
+%
+Approved for veterans.
+%
+As seen on TV.
+%
+At participating locations only.
+%
+Available while quantities last.
+%
+Availability is limited.
+%
+Avoid contact with eyes.
+%
+Avoid contact with skin.
+%
+Batteries not included.
+%
+Best if used before date on carton.
+%
+Be sure each item is properly endorsed.
+%
+Beware of dog.
+%
+Blackout restrictions apply.
+%
+Blend until smooth.
+%
+Booths for two or more.
+%
+Breaking seal constitutes acceptance of agreement.
+%
+Buckle up!
+%
+Call for details.
+%
+Call toll free number before digging.
+%
+Check here if tax deductible.
+%
+Check your local listings.
+%
+Cleanse area thoroughly before applying.
+%
+Close cover before striking.
+%
+Closed weekends and holidays.
+%
+Colors may fade.
+%
+Colors may fade in time.
+%
+Consumption of alcoholic beverages impairs your ability to drive a car and may
+cause health problems.
+%
+Contains a substantial amount of non-tobacco ingredients.
+%
+Contains no artificial colors or ingredients.
+%
+Contents may settle during shipment.
+%
+May cause drowsiness.
+%
+Contestants have been briefed on some questions before the show.
+%
+Contest void where prohibited by law.
+%
+Danger: do not shake.
+%
+Dealer prices may vary.
+%
+Do not try this at home.
+%
+Do not flush.
+%
+These statements have not been evaluated by the Food and Drug Administration.
+%
+Substantial risk of electric shock.
+%
+Does not include installation.
+%
+Do not apply to broken skin.
+%
+Do not attempt this in your home.
+%
+Do not cut switchbacks.
+%
+Do not disturb.
+%
+Do not drink and drive.
+%
+Do not dry clean.
+%
+Do not exceed recommended dosage.
+%
+Do not fold, spindle or mutilate.
+%
+Do not incinerate: contents under pressure.
+%
+Do not open shrink-wrap until you have read and agreed to the conditions
+contained within.
+%
+Do not pick the flowers.
+%
+Do not remove tag under penalty of law.
+%
+Do not stamp.
+%
+Do not use if foil seal is broken.
+%
+Do not use while operating a motor vehicle or heavy machinery.
+%
+Do not write below this line.
+%
+Do not write in this space.
+%
+Driver does not carry cash.
+%
+Serving suggestion.
+%
+Made with real ingredients.
+%
+Drop in any mailbox.
+%
+Dry clean only.
+%
+Edited for television.
+%
+Employees and their families are not eligible.
+%
+Employees must wash hands before returning to work.
+%
+Exact change only.
+%
+Falling rock.
+%
+Federal law prohibits dispensing without a prescription.
+%
+Filmed before a live audience.
+%
+First pull up, then pull down.
+%
+For best results, follow directions carefully.
+%
+For external use only.
+%
+For internal use only.
+%
+Formatted to fit your screen.
+%
+For office use only.
+%
+For off-road use only.
+%
+For recreational use only.
+%
+For reservations, call your travel agent.
+%
+Freshest if eaten before date on carton.
+%
+From concentrate.
+%
+If condition persists, consult your physician.
+%
+If not completely satisfied, return for full refund of purchase price.
+%
+If rash develops, discontinue use.
+%
+List current at time of printing.
+%
+If redness or swelling develop, consult physician promptly.
+%
+Illegally parked cars will be towed at owner's expense.
+%
+In specially marked packages only.
+%
+Inspired by a true story.
+%
+Keep away from edge.
+%
+Keep away from fire or flame.
+%
+Keep cool.
+%
+Keep cool; process promptly.
+%
+Keep hands and feet away from moving parts at all times.
+%
+Keep out of reach of children.
+%
+Keep out of the sunlight.
+%
+Keep refrigerated.
+%
+Keep this and all chemicals out of the reach of children.
+%
+Limitations on coverage and remedies apply.
+%
+Limited delivery area.
+%
+Limited time offer, call now to ensure prompt delivery.
+%
+List at least two alternate dates.
+%
+List each check separately by bank number.
+%
+List was current at time of printing.
+%
+Lost ticket pays maximum rate.
+%
+Many suitcases look alike.
+%
+May be too intense for some viewers.
+%
+May explode if improperly recharged.
+%
+May not be reproduced, in whole or in part, by any means, mechanical or
+electronic, except for brief excerpts for the purpose of inclusion in reviews.
+%
+Membership dues are not refundable.
+%
+Merchandise can be shipped only upon receipt of payment.
+%
+Might not be suitable for persons suffering from weak hearts.
+%
+Minimum charge for booths.
+%
+Misuse may cause suffocation.
+%
+Monitor not included.
+%
+Motorized vehicles only.
+%
+Must be over 18.
+%
+Must be over 21.
+%
+Must be under 48 inches in height.
+%
+New customers only.
+%
+Licensed and bonded.
+%
+No alcohol, dogs or horses.
+%
+No anchovies unless otherwise specified.
+%
+No animals were injured.
+%
+Monitored by the American Human Association.
+%
+No campfires allowed.
+%
+Do not use or store near heat or open flame.
+%
+Will stain.
+%
+Disposable, use only once.
+%
+Causes moderate eye irritation.
+%
+No Canadian coins.
+%
+No foreign coins.
+%
+No lifeguard on duty.
+%
+No motorized vehicles allowed.
+%
+No other warranty expressed or implied.
+%
+No passes accepted for this engagement.
+%
+No passing.
+%
+No passing zone.
+%
+No postage necessary if mailed in the United States.
+%
+No purchase necessary.
+%
+No running on pool deck.
+%
+No shirt, no shoes, no service.
+%
+No solicitors.
+%
+No stopping or standing.
+%
+Not affiliated with the American Red Cross.
+%
+Not a flying toy.
+%
+Celebrity voices impersonated.
+%
+Not exactly as shown.
+%
+Not for human consumption.
+%
+Not from concentrate.
+%
+No transfers issued until the bus comes to a complete stop.
+%
+May contain nuts.
+%
+Not recommended for children.
+%
+Not responsible for lost or stolen articles.
+%
+Not responsible for merchandise left over 30 days.
+%
+Not responsible for typographical errors.
+%
+Not valid with other offers or specials.
+%
+Other restrictions may apply.
+%
+May not be combined with other discounts.
+%
+Obey all traffic laws.
+%
+Objects in mirror may be closer than they appear.
+%
+Offer limited to residents of the contiguous United States.
+%
+Offer may end without notice.
+%
+Offer void where prohibited by law.
+%
+One size fits all.
+%
+Opened for inspection.
+%
+Orders subject to approval.
+%
+Package sold by weight, not volume.
+%
+Pass with care.
+%
+Pay toll ahead.
+%
+Penalty for private use.
+%
+Place stamp here.
+%
+Please come again.
+%
+Please read the prospectus carefully before you invest or send money.
+%
+Please recycle.
+%
+Please remain seated until the ride has come to a complete stop.
+%
+Portions not affecting outcome have been edited for broadcast.
+%
+Positively no smoking.
+%
+Postage will be paid by addressee.
+%
+Post no bills.
+%
+Post office will not deliver without proper postage.
+%
+Prerecorded for this time zone.
+%
+Prevent forest fires.
+%
+Price does not include taxes.
+%
+Prices higher in Alaska and Hawaii.
+%
+Prices subject to change without notice.
+%
+Printed on recycled paper.
+%
+Processed at location stamped in code at top of carton.
+%
+Process promptly.
+%
+Professional driver on closed track.
+%
+Management is not responsible for loss or damage.
+%
+Professional sample - not for sale.
+%
+Protect from light.
+%
+Read terms and conditions.
+%
+Read the fine print.
+%
+Reapply as necessary.
+%
+Record additional transactions on back of previous stub.
+%
+Replace with same type.
+%
+Restaurant package, not for resale.
+%
+Results are not typical.
+%
+Results vary by individual.
+%
+Returns for store credit only.
+%
+Sales tax applies.
+%
+Sanitized for your protection.
+%
+See label for sequence.
+%
+See other side for additional listings.
+%
+See store for details.
+%
+Sell by date stamped on bottom.
+%
+Send a self-addressed, stamped envelope.
+%
+Shading within a garment may occur.
+%
+Shake well before using.
+%
+Shipping not included.
+%
+Show night or time may vary in your market.
+%
+Shut off engine before fueling.
+%
+Sign here without admitting guilt.
+%
+Simulated picture.
+%
+Slippery when wet.
+%
+Some assembly required.
+%
+Some equipment shown is optional.
+%
+Some of the trademarks mentioned in this product appear for identification
+purposes only.
+%
+Some optional equipment shown.
+%
+Some restrictions may apply.
+%
+Some settling may occur.
+%
+Some stirring may be necessary to achieve proper consistency.
+%
+Space is limited.
+%
+Special engagement; no discounts, passes or coupons accepted.
+%
+Specifications subject to change without notice.
+%
+Stay on the trail.
+%
+Stay seated until bus comes to a complete stop.
+%
+Stop ahead.
+%
+Store in a cool place.
+%
+Subject to change without notice.
+%
+Holiday and other blackout periods apply.
+%
+Substantial penalty for early withdrawal.
+%
+Swim at your own risk.
+%
+Tax and title extra.
+%
+Tax, title, tag, and dealer handling not included.
+%
+The inclusion of any link does not imply endorsement of the site.
+%
+The Surgeon General has determined that cigarette smoking is hazardous to your
+health.
+%
+This bag is recyclable.
+%
+This end up.
+%
+This is not an offer to sell securities.
+%
+This space intentionally left blank.
+%
+This supersedes all previous notices.
+%
+Times approximate.
+%
+To avoid suffocation, keep away from children.
+%
+To order, call toll-free.
+%
+To reduce printing costs, we have sent you only the forms you may need based on
+what you filed last year.
+%
+Touch tone phones only.
+%
+Truckers welcome.
+%
+Turn off engine while fueling.
+%
+Use at own risk.
+%
+Used with permission.
+%
+Use extra care when cleaning on stairs.
+%
+Use in well-ventilated area.
+%
+Use of software is governed by the terms of the end user license agreement.
+%
+Use only as directed.
+%
+Use only in a well-ventilated area.
+%
+Not intended to diagnose, treat, cure or prevent any disease.
+%
+Do not use if printed inner seal is broken or missing.
+%
+Use other side for additional listings.
+%
+Views expressed may not be those of the sponsor.
+%
+Void where prohibited by law.
+%
+We make our mailing list available to selected organizations.
+%
+While supplies last.
+%
+You must be present to win.
+%
+You need not be present to win.
+%
+Your canceled check is your receipt.
+%
+Your compliance with all terms and conditions, expressed and implied, is
+automatic upon viewing.
+%
+Your daily dietary values may be higher or lower depending on your caloric
+needs.
+%
+Your financial institution may impose additional fees and charges.
+%
+Your mileage may vary.
+%


### PR DESCRIPTION
Back in 2004 I put together a fortune-mod data file of disclaimers, and submitted it to the Debian maintainer. It looks like it never made it upstream, so I've fished out the old e-mail, grabbed the file attachment, and put together this pull request.

The disclaimers should all be 'clean'. I like to put 'fortune disclaimer' in my shell login script, because I use systems which display mandatory legal verbiage every time I log in.