### PR TITLE
fix typo in word 'multiple'

### DIFF
--- a/fortune-mod/datfiles/linux
+++ b/fortune-mod/datfiles/linux
@@ -1391,7 +1391,7 @@ You got me worried there for a brief (very brief) moment :-).
 	-- Seen on #Debian
 %
 When you have 200 programmers trying to write code for one
-product, like Win95 or NT, what you get is a multipule personality
+product, like Win95 or NT, what you get is a multiple personality
 program.  By definition, the real problem is that these programs are
 psychotic by nature and make people crazy when they use them.
 	-- Joan Brewer on alt.destroy.microsoft


### PR DESCRIPTION
Nothing gets my goat like a receiving a typo from my fortune command.