### PR TITLE
Actually use LOCAL{,O}DIR as install location

### DIFF
--- a/fortune-mod/datfiles/CMakeLists.txt
+++ b/fortune-mod/datfiles/CMakeLists.txt
@@ -36,7 +36,7 @@ FOREACH(c ${COOKIES})
 
     INSTALL(
         FILES "${c}" "${CMAKE_CURRENT_BINARY_DIR}/${DEST}" "${CMAKE_CURRENT_BINARY_DIR}/${LINK}"
-        DESTINATION "share/games/fortunes"
+        DESTINATION "${LOCALDIR}"
     )
 
 ENDFOREACH()

--- a/fortune-mod/datfiles/off/CMakeLists.txt
+++ b/fortune-mod/datfiles/off/CMakeLists.txt
@@ -39,7 +39,7 @@ FOREACH(c ${OFFENSIVE_COOKIES})
 
     INSTALL(
         FILES "${rot_dest}" "${CMAKE_CURRENT_BINARY_DIR}/${DEST}" "${rot_LINK}"
-        DESTINATION "share/games/fortunes/off"
+        DESTINATION "${LOCALODIR}"
     )
 
 ENDFOREACH()


### PR DESCRIPTION
Being cached cmake variables the expection is that they can be
changed but in that case the definitions and actual install
locations are different.