### PR TITLE
Fixed typo equpped -> equipped

### DIFF
--- a/fortune-mod/datfiles/computers
+++ b/fortune-mod/datfiles/computers
@@ -5049,7 +5049,7 @@ When we write programs that "learn", it turns out we do and they don't.
 Whenever a system becomes completely defined, some damn fool discovers
 something which either abolishes the system or expands it beyond recognition.
 %
-Where a calculator on the ENIAC is equpped with 18,000 vacuum tubes and
+Where a calculator on the ENIAC is equipped with 18,000 vacuum tubes and
 weighs 30 tons, computers in the future may have only 1,000 vaccuum tubes
 and perhaps weigh 1 1/2 tons.
 		-- Popular Mechanics, March 1949


### PR DESCRIPTION
In fortune-mod/datfiles/computers fixes apparent typo from 'Where a calculator on the ENIAC is equpped with 18,000 vacuum tubes' to 'Where a calculator on the ENIAC is equipped with 18,000 vacuum tubes'.