### PR TITLE
Make recode support work again

### DIFF
--- a/fortune-mod/config.h.in
+++ b/fortune-mod/config.h.in
@@ -16,6 +16,9 @@ extern "C" {
 #define OFFDIR "${OCOOKIEDIR}"
 #define FORTDIR "${COOKIEDIR}"
 
+/* Defined if you have recode */
+#cmakedefine HAVE_RECODE_H
+
 #ifdef __cplusplus
 }
 #endif

--- a/fortune-mod/fortune/fortune.c
+++ b/fortune-mod/fortune/fortune.c
@@ -79,6 +79,7 @@
 
 #define PROGRAM_NAME "fortune-mod"
 
+#include "config.h"
 #include "fortune-mod-common.h"
 
 #include <dirent.h>
@@ -100,8 +101,6 @@
 #ifdef HAVE_REGEX_H
 #include <regex.h>
 #endif
-
-#include "config.h"
 
 #define MINW 6   /* minimum wait if desired */
 #define CPERS 20 /* # of chars for each sec */


### PR DESCRIPTION
45c25e3cbc2e1a96db4ad9a89dd538d162eef47c made recode an optional
dependency. check_include_files sets HAVE_RECODE_H, which is a cmake
cache variable but that's not in the scope of the preprocessor, so
WITH_RECODE is never defined because HAVE_RECODE_H is not.