### PR TITLE
Update Ferengi Rules of Acquisition

### DIFF
--- a/fortune-mod/datfiles/rules-of-acquisition
+++ b/fortune-mod/datfiles/rules-of-acquisition
@@ -1,926 +1,648 @@
-Ferengi Rules Of Acquisition:
-1.  Once you have their money, never give it back
-%
-Ferengi Rules Of Acquisition:
-2.  You can't cheat an honest customer, but it never hurts to try
-%
-Ferengi Rules Of Acquisition:
-3.  Never spend more for an acquisition than you have to
-%
-Ferengi Rules Of Acquisition:
-4.  Sex and profit are the two things that never last long enough
-%
-Ferengi Rules Of Acquisition:
-5.  If you can't break a contract, bend it
-%
-Ferengi Rules Of Acquisition:
-6.  Never let family stand in the way of opportunity
-%
-Ferengi Rules Of Acquisition:
-7.  Always keep you ears open
-%
-Ferengi Rules Of Acquisition:
-8.  Keep count of your change
-%
-Ferengi Rules Of Acquisition:
-9.  Instinct plus opportunity equals profit
-%
-Ferengi Rules Of Acquisition:
-10.  A dead customer can't buy as much as a live one
-%
-Ferengi Rules Of Acquisition:
-11.  Latinum isn't the only thing that shines
-%
-Ferengi Rules Of Acquisition:
-12.  Anything worth selling is worth selling twice
-%
-Ferengi Rules Of Acquisition:
-13.  Anything worth doing is worth doing for money
-%
-Ferengi Rules Of Acquisition:
-14.  Anything stolen is pure profit
-%
-Ferengi Rules Of Acquisition:
-15.  Acting stupid is often smart
-%
-Ferengi Rules Of Acquisition:
-16.  A deal is a deal ... until a better one comes along
-%
-Ferengi Rules Of Acquisition:
-17.  A bargain usually isn't
-%
-Ferengi Rules Of Acquisition:
-18.  A Ferengi without profit is no Ferengi at all
-%
-Ferengi Rules Of Acquisition:
-19.  Don't lie too soon after a promotion
-%
-Ferengi Rules Of Acquisition:
-20.  When the customer is sweating, turn up the heat
-%
-Ferengi Rules Of Acquisition:
-21.  Never place friend ship before profit
-%
-Ferengi Rules Of Acquisition:
-22.  wise men can hear profit in the wind
-%
-Ferengi Rules Of Acquisition:
-23.  Never take the last coin, but be sure to get the rest
-%
-Ferengi Rules Of Acquisition:
-24.  Never ask when you can take
-%
-Ferengi Rules Of Acquisition:
-25.  Fear makes a good business partner
-%
-Ferengi Rules Of Acquisition:
-26.  The vast majority of the rich in this galaxy did not inherit their wealth;
-they stole it
-%
-Ferengi Rules Of Acquisition:
-27.  The most beautiful thing about a tree is what you do with it after you cut
-it down
-%
-Ferengi Rules Of Acquisition:
-28.  Morality is always defined by those in power
-%
-Ferengi Rules Of Acquisition:
-29.  When someone says "It's not the money," they're lying
-%
-Ferengi Rules Of Acquisition:
-30.  Talk is cheap; synthehol costs money
-%
-Ferengi Rules Of Acquisition:
-31.  Never make fun of a Ferengi's mother
-%
-Ferengi Rules Of Acquisition:
-32.  Be careful what you sell. It may do exactly what the customer expects
-%
-Ferengi Rules Of Acquisition:
-33.  It never hurts to suck up to the boss
-%
-Ferengi Rules Of Acquisition:
-34. War is good for business
-%
-Ferengi Rules Of Acquisition:
-35.  Peace is good for business
-%
-Ferengi Rules Of Acquisition:
-36.  Too many Ferengi can't laugh at themselves anymore
-%
-Ferengi Rules Of Acquisition:
-37.  You can always buy back a lost reputation
-%
-Ferengi Rules Of Acquisition:
-38.  Free advertising is cheap
-%
-Ferengi Rules Of Acquisition:
-39.  Praise is cheap. Heap it generously on all customers
-%
-Ferengi Rules Of Acquisition:
-40.  If you see profit on a journey, take it
-%
-Ferengi Rules Of Acquisition:
-41.  Money talks, but having a lots of it gets more attention
-%
-Ferengi Rules Of Acquisition:
-42.  Only negotiate when you are certain to profit
-%
-Ferengi Rules Of Acquisition:
-43.  Caressing an ear is often more forceful than pointing a weapon
-%
-Ferengi Rules Of Acquisition:
-44.  Never argue with a loaded phaser
-%
-Ferengi Rules Of Acquisition:
-45.  profit has limits. Loss has none
-%
-Ferengi Rules Of Acquisition:
-46.  Labor camps are full of people who trusted the wrong person
-%
-Ferengi Rules Of Acquisition:
-47.  Never trust a man wearing a better suit than you own
-%
-Ferengi Rules Of Acquisition:
-48.  The bigger the smile, the sharper the knife
-%
-Ferengi Rules Of Acquisition:
-49.  Old age and greed will always overcome youth and talent
-%
-Ferengi Rules Of Acquisition:
-50.  Never bluff a Klingon
-%
-Ferengi Rules Of Acquisition:
-51.  Never admit a mistake if there's someone else to blame
-%
-Ferengi Rules Of Acquisition:
-52.  Only Bugsy could have built Las Vegas
-%
-Ferengi Rules Of Acquisition:
-53.  Sell first; ask questions later
-%
-Ferengi Rules Of Acquisition:
-54.  Never buy anything you can't sell
-%
-Ferengi Rules Of Acquisition:
-55.  Always sell at the highest possible profit
-%
-Ferengi Rules Of Acquisition:
-56.  Pursue profit; women come later
-%
-Ferengi Rules Of Acquisition:
-57.  Good customers are almost as rare as Latinum - treasure them
-%
-Ferengi Rules Of Acquisition:
-58.  Friendship is seldom cheap
-%
-Ferengi Rules Of Acquisition:
-59.  Fee advice is never cheap
-%
-Ferengi Rules Of Acquisition:
-60.  Never use Latinum where your words will do
-%
-Ferengi Rules Of Acquisition:
-61.  Never buy what can be stolen
-%
-Ferengi Rules Of Acquisition:
-62.  The riskier the road, the greater the profit
-%
-Ferengi Rules Of Acquisition:
-63.  power without profit is like a ship without an engine
-%
-Ferengi Rules Of Acquisition:
-64.  Don't talk shop; talk shopping
-%
-Ferengi Rules Of Acquisition:
-65.  Don't talk ship; talk shipping
-%
-Ferengi Rules Of Acquisition:
-66.  Anyone serving in a fleet who is crazy can be relieved, if they ask for it
-%
-Ferengi Rules Of Acquisition:
-67.  Enough is never enough
-%
-Ferengi Rules Of Acquisition:
-68.  Compassion is no substitute for a profit
-%
-Ferengi Rules Of Acquisition:
-69.  You could afford your ship without your government - if it weren't for
-your government
-%
-Ferengi Rules Of Acquisition:
-70.  Get the money first, then let the buyers worry about collecting the
-merchandise
-%
-Ferengi Rules Of Acquisition:
-71.  Gamble and trade have two things in common: risk and Latinum
-%
-Ferengi Rules Of Acquisition:
-72.  Never let the competition know, what you're thinking
-%
-Ferengi Rules Of Acquisition:
-73.  Never trust advice from a dying Ferengi; listen but don't trust
-%
-Ferengi Rules Of Acquisition:
-74.  A Ferengi without profit is no Ferengi at all
-%
-Ferengi Rules Of Acquisition:
-75.  Home is where the heart is, but the stars are made of Latinum
-%
-Ferengi Rules Of Acquisition:
-76.  Every once in a while, declare peace. It confuses the hell out of your
-enemies
-%
-Ferengi Rules Of Acquisition:
-77.  Go where no Ferengi has gone before; where there is no reputation there is
-profit
-%
-Ferengi Rules Of Acquisition:
-78.  There is a customer born every minute
-%
-Ferengi Rules Of Acquisition:
-79.  Beware of the Vulcan greed for knowledge
-%
-Ferengi Rules Of Acquisition:
-80.  If it works, sell it. If it works well, sell it for more. If it doesn't
-work, quadruple the price and sell it as an antique
-%
-Ferengi Rules Of Acquisition:
-81.  There's nothing more dangerous than an honest businessman
-%
-Ferengi Rules Of Acquisition:
-82.  A smart customer is not a good customer
-%
-Ferengi Rules Of Acquisition:
-83.  Revenge is profitless
-%
-Ferengi Rules Of Acquisition:
-84.  She can touch your ears but never your Latinum
-%
-Ferengi Rules Of Acquisition:
-85.  Death takes no bribes
-%
-Ferengi Rules Of Acquisition:
-86.  A wife is a luxury,  a smart accountant a necessity
-%
-Ferengi Rules Of Acquisition:
-87.  Trust is the biggest liability of all
-%
-Ferengi Rules Of Acquisition:
-88.  When the boss comes to dinner, it never hurts to have the wife wear
-something
-%
-Ferengi Rules Of Acquisition:
-89.  Latinum lasts longer than lust
-%
-Ferengi Rules Of Acquisition:
-90.  Mine is better than ours
-%
-Ferengi Rules Of Acquisition:
-91.  He who drinks fast pays slow
-%
-Ferengi Rules Of Acquisition:
-92.  Never confuse wisdom with luck
-%
-Ferengi Rules Of Acquisition:
-93.  He's a fool who makes his doctor his heir
-%
-Ferengi Rules Of Acquisition:
-94.  Beware of small expenses: a small leak will kill a ship
-%
-Ferengi Rules Of Acquisition:
-95.  Important, more impotant, Latinum
-%
-Ferengi Rules Of Acquisition:
-96.  Faith moves mountains - of inventory
-%
-Ferengi Rules Of Acquisition:
-97.  If you would keep a secret from an enemy, don't tell it to a friend
-%
-Ferengi Rules Of Acquisition:
-98.  Profit is the better part of valor
-%
-Ferengi Rules Of Acquisition:
-99.  Never trust a wise man
-%
-Ferengi Rules Of Acquisition:
-100.  Everything that has no owner, needs one
-%
-Ferengi Rules Of Acquisition:
-101.  Never do something you can make someone do for you
-%
-Ferengi Rules Of Acquisition:
-102.  Nature decays, but Latinum lasts forever
-%
-Ferengi Rules Of Acquisition:
-103.  Sleep can interfere with opportunity
-%
-Ferengi Rules Of Acquisition:
-104.  Money is never made. It is merely won or lost
-%
-Ferengi Rules Of Acquisition:
-105.  Wise men don't lie, they just bend the truth
-%
-Ferengi Rules Of Acquisition:
-106.  There is no honor in poverty
-%
-Ferengi Rules Of Acquisition:
-107.  Win or lose, there's always Huyperian Beetle Snuff
-%
-Ferengi Rules Of Acquisition:
-108.  A woman wearing clothes is like a man without profit
-%
-Ferengi Rules Of Acquisition:
-109.  Dignity and an empty sack is worth the sack
-%
-Ferengi Rules Of Acquisition:
-110.  Only a fool passes up a business opportunity
-%
-Ferengi Rules Of Acquisition:
-111.  Treat people in your debt like family ... exploit them
-%
-Ferengi Rules Of Acquisition:
-112.  Never sleep with the boss's wife unless you pay him first
-%
-Ferengi Rules Of Acquisition:
-113.  Never sleep with the boss's sister
-%
-Ferengi Rules Of Acquisition:
-114.  Small print lead to large risk
-%
-Ferengi Rules Of Acquisition:
-115.  Greed is eternal
-%
-Ferengi Rules Of Acquisition:
-116.  There's always a way out
-%
-Ferengi Rules Of Acquisition:
-117.  If the profit seems too good to be true, it usually is
-%
-Ferengi Rules Of Acquisition:
-118.  Never cheat a honest man offering a decent price
-%
-Ferengi Rules Of Acquisition:
-119.  Buy, sell, or get out of the way
-%
-Ferengi Rules Of Acquisition:
-120.  Even a blind man can recognize the glow of Latinum
-%
-Ferengi Rules Of Acquisition:
-121.  Everything is for sale, even friendship
-%
-Ferengi Rules Of Acquisition:
-122.  As the customers go, so goes the wise profiteer
-%
-Ferengi Rules Of Acquisition:
-123.  A friend is only a friend until you sell him something. Then he is a
-customer
-%
-Ferengi Rules Of Acquisition:
-124.  Friendship is temporary, profit is forever
-%
-Ferengi Rules Of Acquisition:
-125.  A lie isn't a lie until someone else knows the truth
-%
-Ferengi Rules Of Acquisition:
-126.  A lie isn't a lie, it's just the truth seen from a different point of
-view
-%
-Ferengi Rules Of Acquisition:
-127.  Gratitude can bring on generosity
-%
-Ferengi Rules Of Acquisition:
-128.  Ferengi are not responsible for the stupidity of other races
-%
-Ferengi Rules Of Acquisition:
-129.  Never trust your customers
-%
-Ferengi Rules Of Acquisition:
-130.  Never trust a beneficiary
-%
-Ferengi Rules Of Acquisition:
-131.  If it gets you profit, sell your own mother
-%
-Ferengi Rules Of Acquisition:
-132.  The flimsier the produce, the higher the price
-%
-Ferengi Rules Of Acquisition:
-133.  Never judge a customer by the size of his wallet ... sometimes good
-things come in small packages
-%
-Ferengi Rules Of Acquisition:
-134.  There's always a catch
-%
-Ferengi Rules Of Acquisition:
-135.  The only value of a collectible is what you can get somebody else to pay
-for it
-%
-Ferengi Rules Of Acquisition:
-136.  The sharp knife cuts quickly. Act without delay!
-%
-Ferengi Rules Of Acquisition:
-137.  Necessity is the mother of invention. Profit is the father
-%
-Ferengi Rules Of Acquisition:
-138.  Law makes everyone equal, but justice goes to the highest bidder
-%
-Ferengi Rules Of Acquisition:
-139.  Wives serve; brother inherit
-%
-Ferengi Rules Of Acquisition:
-140.  The answer to quick and easy profit is: buy for less, sell for more
-%
-Ferengi Rules Of Acquisition:
-141.  Competition and fair play are mutually exclusive. Fait play and financial
-loss go hand-in-hand
-%
-Ferengi Rules Of Acquisition:
-142.  A Ferengi waits to bid until his opponents have exhausted themselves
-%
-Ferengi Rules Of Acquisition:
-143.  The family of Fools is ancient
-%
-Ferengi Rules Of Acquisition:
-144.  There's nothing wrong with charity ... as long as it winds up in your
-pocket
-%
-Ferengi Rules Of Acquisition:
-145.  Always ask for the costs first
-%
-Ferengi Rules Of Acquisition:
-146.  If possible sell neither the sizzle nor the steak, but the Elphasian
-wheat germ
-%
-Ferengi Rules Of Acquisition:
-147.  New customers are like razor toothed gree worms. They can be succulent,
-but sometimes they bite back
-%
-Ferengi Rules Of Acquisition:
-148.  Opportunity waits for no one
-%
-Ferengi Rules Of Acquisition:
-149.  Females and finances don't mix
-%
-Ferengi Rules Of Acquisition:
-150.  Make your shop easy to find
-%
-Ferengi Rules Of Acquisition:
-151.  Sometimes, what you get free costs entirely too much
-%
-Ferengi Rules Of Acquisition:
-152.  Ask not what your profits can do for you; ask what you can do for your
-profits
-%
-Ferengi Rules Of Acquisition:
-153.  You can't free a fish from water
-%
-Ferengi Rules Of Acquisition:
-154.  The difference between manure and Latinum is commerece
-%
-Ferengi Rules Of Acquisition:
-155.  What's mine is mine, and what's yours is mine too
-%
-Ferengi Rules Of Acquisition:
-156.  Even in the worst of times someone turns a profit
-%
-Ferengi Rules Of Acquisition:
-157.  You are surrounded by opportunities; you just have to know where to look
-%
-Ferengi Rules Of Acquisition:
-158.  Don't pay until you have the goods
-%
-Ferengi Rules Of Acquisition:
-159.  The customer is always right ... until you have their cash
-%
-Ferengi Rules Of Acquisition:
-160.  Respect is good, Latinum is better
-%
-Ferengi Rules Of Acquisition:
-161.  Never kill a customer, unless you make more profit out of his death than
-out of his life
-%
-Ferengi Rules Of Acquisition:
-162.  His money is only your's when he can't get it back
-%
-Ferengi Rules Of Acquisition:
-163.  A thirsty customer is good for profit, a drunk one isn't
-%
-Ferengi Rules Of Acquisition:
-164.  Never spend your own money when you can spend someone else's
-%
-Ferengi Rules Of Acquisition:
-165.  Never allow one's culture's law to get in the way of a universal goal:
-profit
-%
-Ferengi Rules Of Acquisition:
-166.  Never give away for free what can be sold
-%
-Ferengi Rules Of Acquisition:
-167.  If a deal is fairly and lawfully made, then seeking revenge especially
-unprofitable revenge, is illegal
-%
-Ferengi Rules Of Acquisition:
-168.  Beware of relatives bearing gifts
-%
-Ferengi Rules Of Acquisition:
-169.  If you're going to have to endure, make yourself comfortable
-%
-Ferengi Rules Of Acquisition:
-170.  Never gamble with an empath
-%
-Ferengi Rules Of Acquisition:
-171.  Time is Latinum. The early Ferengi get the Latinum
-%
-Ferengi Rules Of Acquisition:
-172.  If you can sell it, don't hsitate to steal it
-%
-Ferengi Rules Of Acquisition:
-173.  A piece of Latinum in the hand is worth two in a customer's pocket
-%
-Ferengi Rules Of Acquisition:
-174.  Share and perish
-%
-Ferengi Rules Of Acquisition:
-175.  When everything fails - run
-%
-Ferengi Rules Of Acquisition:
-176.  Ferengi's don't give promotional gifts!
-%
-Ferengi Rules Of Acquisition:
-177.  Know your enemies ... but do business with them always
-%
-Ferengi Rules Of Acquisition:
-178.  The world is a stage - don't forget to demand admission
-%
-Ferengi Rules Of Acquisition:
-179.  Whenever you think that things can't get worse, the FCA will be knocking
-on you door
-%
-Ferengi Rules Of Acquisition:
-180.  Never offer a confession when a bribe will do
-%
-Ferengi Rules Of Acquisition:
-181.  Even dishonesty can't tarnish the glow of Latinum
-%
-Ferengi Rules Of Acquisition:
-182.  Whenever you're being asked if you are god, the right answer is YES
-%
-Ferengi Rules Of Acquisition:
-183.  Genius without opportunity is like Latinum in the mine
-%
-Ferengi Rules Of Acquisition:
-184.  There are three things you must not talk to aliens: sex, religion and
-taxes
-%
-Ferengi Rules Of Acquisition:
-185.  If you want to ruin yourself there are three known ways: Gambling is the
-fastest, women are the sweetest, and banks are the most reliable way
-%
-Ferengi Rules Of Acquisition:
-186.  There are two things that will catch up with you for sure: death and
-taxes
-%
-Ferengi Rules Of Acquisition:
-187.  If your dancing partner wants to lead at all costs, let her have her own
-way and ask another one to dance
-%
-Ferengi Rules Of Acquisition:
-188.  Never bet on a race you haven't fixed
-%
-Ferengi Rules Of Acquisition:
-189.  Borrow on a handshake; lend in writing
-%
-Ferengi Rules Of Acquisition:
-190.  Drive your business or it will drive you
-%
-Ferengi Rules Of Acquisition:
-191.  Let other keep their reputation. You keep their money
-%
-Ferengi Rules Of Acquisition:
-192.  If the flushing isn't strong enough, use your brain and try the brush
-%
-Ferengi Rules Of Acquisition:
-193.  Klingon women don't dance tango
-%
-Ferengi Rules Of Acquisition:
-194.  It's always good business to know about new customers before they walk in
-your door
-%
-Ferengi Rules Of Acquisition:
-195.  Wounds heal, but debt is forever
-%
-Ferengi Rules Of Acquisition:
-196.  Only give money to people you know you can steal from
-%
-Ferengi Rules Of Acquisition:
-197.  Never trust your customers, especially if they are your relatives
-%
-Ferengi Rules Of Acquisition:
-198.  Employees are the rungs on your ladder to success - don't hesitate to
-step on them
-%
-Ferengi Rules Of Acquisition:
-199.  The secret of one person is another person's opportunity
-%
-Ferengi Rules Of Acquisition:
-200.  A madman with Latinum means profit without return
-%
-Ferengi Rules Of Acquisition:
-201.  The justification for profit is profit
-%
-Ferengi Rules Of Acquisition:
-202.  a)  A friend in need is a customer in the making
-      b)  A friend in need means three times the profit
-%
-Ferengi Rules Of Acquisition:
-203.  A Ferengi in need, will never do anything for free
-%
-Ferengi Rules Of Acquisition:
-204.  When the Grand Nagus arrives to offer you a business opportunity, it's
-time to leave town until he's gone
-%
-Ferengi Rules Of Acquisition:
-205.  When the customer dies, the money stops a-comin'
-%
-Ferengi Rules Of Acquisition:
-206.  Fighting with Klingons is like gambling with Cardassians - it's good to
-have a friend around when you lose
-%
-Ferengi Rules Of Acquisition:
-207.  Never trust a hardworking employee
-%
-Ferengi Rules Of Acquisition:
-208.  Give someone a fish, you feed him for one day.  Teach him how to fish,
-and you lose a steady customer
-%
-Ferengi Rules Of Acquisition:
-209.  Tell them what they want to hear
-%
-Ferengi Rules Of Acquisition:
-210.  A wife, who is able to clean, saves the cleaning lady
-%
-Ferengi Rules Of Acquisition:
-211.  In business deals, a disruptor can be almost as important as a calculator
-%
-Ferengi Rules Of Acquisition:
-212.  If they accept your first offer, you either asked too little or offered
-too much
-%
-Ferengi Rules Of Acquisition:
-213.  Stay neutral in conflicts so that you can sell supplies to both sides
-%
-Ferengi Rules Of Acquisition:
-214.  Never begin a business transaction on an empty stomach
-%
-Ferengi Rules Of Acquisition:
-215.  Instinct without opportunity is useless
-%
-Ferengi Rules Of Acquisition:
-216.  Never take hospitality from someone worse off than yourself
-%
-Ferengi Rules Of Acquisition:
-217.  Only pay for it, if you are confronted with loaded phaser
-%
-Ferengi Rules Of Acquisition:
-218.  Always know what you're buying
-%
-Ferengi Rules Of Acquisition:
-219.  A friend is not a friend if he asks for a discount
-%
-Ferengi Rules Of Acquisition:
-220.  Profit is like a bed of roses - a few thorns are inevitable
-%
-Ferengi Rules Of Acquisition:
-221.  Beware of any man who thinks with his lobes
-%
-Ferengi Rules Of Acquisition:
-222.  Knowledge is Latinum
-%
-Ferengi Rules Of Acquisition:
-223.  Rich men don't come to buy; they come to take
-%
-Ferengi Rules Of Acquisition:
-224.  Never throw anything away: It may be worht a lot of Latinum some Stardate
-%
-Ferengi Rules Of Acquisition:
-225.  Pride comes before a loss
-%
-Ferengi Rules Of Acquisition:
-226.  Don't take your family for granted, only their Latinum
-%
-Ferengi Rules Of Acquisition:
-227.  Loyalty can be bought ... and sold
-%
-Ferengi Rules Of Acquisition:
-228.  All things come to those who wait, even Latinum
-%
-Ferengi Rules Of Acquisition:
-229.  Beware the man who doesn't make time for oo-mox
-%
-Ferengi Rules Of Acquisition:
-230.  Manipulation may be a Ferengi's greatest tool, and liability
-%
-Ferengi Rules Of Acquisition:
-231.  If you steal it, make sure it has a warranty
-%
-Ferengi Rules Of Acquisition:
-232.  Life's no fair (How else would you turn a profit?)
-%
-Ferengi Rules Of Acquisition:
-233.  Every dark cloud has a Latinum lining
-%
-Ferengi Rules Of Acquisition:
-234.  Never deal with beggars; it's bad for profits
-%
-Ferengi Rules Of Acquisition:
-235.  Don't trust anyone who trusts you
-%
-Ferengi Rules Of Acquisition:
-236.  You can't buy fate
-%
-Ferengi Rules Of Acquisition:
-237.  There's a sucker born every minute.  Be sure you're the first to find
-each one
-%
-Ferengi Rules Of Acquisition:
-238.  The truth will cost
-%
-Ferengi Rules Of Acquisition:
-239.  Ambition knows no family
-%
-Ferengi Rules Of Acquisition:
-240.  The higher you bid, the more customers you drive away
-%
-Ferengi Rules Of Acquisition:
-241.  Never underestimate the inportance of the fist impression
-%
-Ferengi Rules Of Acquisition:
-242.  More is good, all is better
-%
-Ferengi Rules Of Acquisition:
-243.  If you got something nice to say, then SHOUT
-%
-Ferengi Rules Of Acquisition:
-244.  If you can't sell it, sit on it, but never give it away
-%
-Ferengi Rules Of Acquisition:
-245.  A warranty is valid only if they can find you
-%
-Ferengi Rules Of Acquisition:
-246.  He that speaks ill of the wares will buy them
-%
-Ferengi Rules Of Acquisition:
-247.  Never question luck
-%
-Ferengi Rules Of Acquisition:
-248.  Celebrate when you are paid, not, when you are promised
-%
-Ferengi Rules Of Acquisition:
-249.  Respect other culture's beliefs; they'll be more likely to give you money
-%
-Ferengi Rules Of Acquisition:
-250.  A dead vendor doesn't demand money
-%
-Ferengi Rules Of Acquisition:
-251.  Satisfaction is not guaranteed
-%
-Ferengi Rules Of Acquisition:
-252.  Let the buyer beware
-%
-Ferengi Rules Of Acquisition:
-253.  A contract without fine print is a fool's document
-%
-Ferengi Rules Of Acquisition:
-254.  Anyone who can't tell a fake doesn't deserve the real thing
-%
-Ferengi Rules Of Acquisition:
-255.  A warranty without loop-holes is a liability
-%
-Ferengi Rules Of Acquisition:
-256.  Synthehol is the lubricant of choice for a customer's stuck purse
-%
-Ferengi Rules Of Acquisition:
-257.  Only fools negotiate with their own money
-%
-Ferengi Rules Of Acquisition:
-258.  A Ferengi is only as important as the amount of Latinum he carries in his
-pockets
-%
-Ferengi Rules Of Acquisition:
-259.  A lie is a way to tell the truth to someone who doesn't know
-%
-Ferengi Rules Of Acquisition:
-260.  Gambling is like the way to power: The only way to win is to cheat, but
-don't get caught in the process
-%
-Ferengi Rules Of Acquisition:
-261.  A wealthy man can afford everything except a conscience
-%
-Ferengi Rules Of Acquisition:
-262.  No lobes, no profit
-%
-Ferengi Rules Of Acquisition:
-263.  Never let a female in clothes cloud your sense of profit
-%
-Ferengi Rules Of Acquisition:
-264.  It's not the size of your planet, but it's income, that matters
-%
-Ferengi Rules Of Acquisition:
-265.  The fear of loss may be your greatest enemy or your best friend - choose
-wisely
-%
-Ferengi Rules Of Acquisition:
-266.  A pair of good ears will ring dry a hundred tongues
-%
-Ferengi Rules Of Acquisition:
-267.  Wish not so much to live Long, as to live well
-%
-Ferengi Rules Of Acquisition:
-268.  a) When in doubt, lie
-      b) When in doubt, buy
-      c) When in doubt, demand more money
-      d) When in doubt, shoot them, take their money, run and blame someone
-      else
-%
-Ferengi Rules Of Acquisition:
-269.  Never purchase anything that has been promised to be valuable or go up in
-value
-%
-Ferengi Rules Of Acquisition:
-270.  It's better to have gambled and lost than to never have gambled at all
-%
-Ferengi Rules Of Acquisition:
-271.  There's many witty men whose brains can't line their pockets
-%
-Ferengi Rules Of Acquisition:
-272.  The way to a Ferengi's heart is through his wallet
-%
-Ferengi Rules Of Acquisition:
-273.  Always count their Latinum before selling anything
-%
-Ferengi Rules Of Acquisition:
-274.  There is no profit in love; however, a strong heart is worth a few bars
-of Latinum on the open market. Keep it on ice
-%
-Ferengi Rules Of Acquisition:
-275.  Latinum can't buy happiness, but you can sure have a blast renting it
-%
-Ferengi Rules Of Acquisition:
-276.  If at first you don't succeed, try to acquire again
-%
-Ferengi Rules Of Acquisition:
-277.  Diamonds may be girl's best friend, but you can only buy the girl with
-Latinum
-%
-Ferengi Rules Of Acquisition:
-278.  It's better to swallow your pride than to lose your profit
-%
-Ferengi Rules Of Acquisition:
-279.  Never close a deal too soon after a female strokes your lobes
-%
-Ferengi Rules Of Acquisition:
-280.  An empty bag can not stand upright
-%
-Ferengi Rules Of Acquisition:
-281.  Blood is thicker than water, but harder to sell
-%
-Ferengi Rules Of Acquisition:
-282.  Business is like war; it's important to recognize the winner
-%
-Ferengi Rules Of Acquisition:
-283.  Rules are always subject to change
-%
-Ferengi Rules Of Acquisition:
-284.  Rules are always subject to interpretation
-%
-Ferengi Rules Of Acquisition:
-285.  No good deed ever goes unpunished
-%
-Ferengi Rules Of Acquisition:
-286.  When Morn leaves it is all over
-%
-Ferengi Rules Of Acquisition:
-287.  Whenever you exploit someone, it never hurts to thank them. That way,
-it's easier to exploit them the next time. (Neelix made this rule up)
-%
-Ferengi Rules Of Acquisition:
-The Unwritten Rule: When no appropriate Rule applies, make one up!
-%
-Zek's Revised Ferengi Rules of Acquisition:
-Rule 001 » If they want their money back, give it to them.
-%
-Zek's Revised Ferengi Rules of Acquisition:
-Rule 010 » Greed is dead.
-%
-Zek's Revised Ferengi Rules of Acquisition:
-Rule 021 » Never place profit before friendship.
-%
-Zek's Revised Ferengi Rules of Acquisition:
-Rule 022 » Latinum tarnishes, but family is forever.
-%
-Zek's Revised Ferengi Rules of Acquisition:
-Rule 023 » Money can never replace dignity.
-%
-Zek's Revised Ferengi Rules of Acquisition:
-Rule 285 » A good deed is its own reward.
+Ferengi Rule of Acquisition #0:
+What the Nagus wants, we acquire.
+-- Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #1:
+Once you have their money, you never give it back.
+-- The Nagus (DS9 episode)
+%
+Ferengi Rule of Acquisition #2:
+The best deal is the one that brings the most profit.
+-- The 34th Rule (DS9 novel)
+%
+Ferengi Rule of Acquisition #2:
+Money is everything.
+-- The Last Tree on Ferenginar: A Ferengi Fable From the Future (DS9 short
+story)
+%
+Ferengi Rule of Acquisition #3:
+Never spend more for an acquisition than you have to.
+-- The Maquis, Part II (DS9 episode)
+%
+Ferengi Rule of Acquisition #4:
+Sedition and treason are always profitable.
+-- Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #5:
+Always exaggerate your estimates.
+-- Cold Fusion (SCE novel)
+%
+Ferengi Rule of Acquisition #6:
+Never allow family to stand in the way of opportunity.
+-- The Nagus (DS9 episode)
+%
+Ferengi Rule of Acquisition #7:
+Keep your ears open.
+-- In the Hands of the Prophets (DS9 episode)
+%
+Ferengi Rule of Acquisition #8:
+Small print leads to large risk.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #9:
+Opportunity plus instinct equals profit.
+-- The Storyteller (DS9 episode)
+%
+Ferengi Rule of Acquisition #10:
+Greed is eternal.
+-- Prophet Motive (DS9 episode)
+%
+Ferengi Rule of Acquisition #13:
+Anything worth doing is worth doing for money.
+-- Legends of the Ferengi (DS9 novel)
+%
+Ferengi Rule of Acquisition #14:
+Sometimes the quickest way to find profits is to let them find you.
+-- Fortune of War (TTN novel)
+%
+Ferengi Rule of Acquisition #15:
+Dead men close no deals.
+-- Demons of Air and Darkness (DS9 novel)
+%
+Ferengi Rule of Acquisition #16:
+A deal is a deal - until a better one comes along.
+-- Melora (DS9 episode), The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #17:
+A contract is a contract is a contract - but only between Ferengi.
+-- Body Parts (DS9 episode)
+%
+Ferengi Rule of Acquisition #18:
+A Ferengi without profit is no Ferengi at all.
+-- Heart of Stone (DS9 episode), Ferengi Love Songs (DS9 episode)
+%
+Ferengi Rule of Acquisition #19:
+Satisfaction is not guaranteed.
+-- Legends of the Ferengi (DS9 novel), The Ferengi Rules of Acquisition (DS9
+reference book)
+%
+Ferengi Rule of Acquisition #20:
+He who dives under the table today lives to profit tomorrow.
+-- Ferenginar: Satisfaction is Not Guaranteed (DS9 novella)
+%
+Ferengi Rule of Acquisition #21:
+Never place friendship above profit.
+-- Rules of Acquisition (DS9 episode)
+%
+Ferengi Rule of Acquisition #22:
+A wise man can hear profit in the wind.
+-- Rules of Acquisition (DS9 episode), False Profits (VOY episode)
+%
+Ferengi Rule of Acquisition #23:
+Nothing is more important than your health - except for your money.
+-- Acquisition (ENT episode)
+%
+Ferengi Rule of Acquisition #25:
+You pay for it, it’s your idea.
+-- Ferenginar: Satisfaction is Not Guaranteed (DS9 novella)
+%
+Ferengi Rule of Acquisition #27:
+There's nothing more dangerous than an honest businessman.
+-- Legends of the Ferengi (DS9 novel)
+%
+Ferengi Rule of Acquisition #29:
+What's in it for me?
+-- Highest Score (DS9 novel)
+%
+Ferengi Rule of Acquisition #30:
+Confidentiality equals profit.
+-- The Badlands, Part IV (DS9 novel)
+%
+Ferengi Rule of Acquisition #31:
+Never make fun of a Ferengi's mother - insult something he cares about instead.
+-- The Siege (DS9 episode), Elite Force II (video game), The Ferengi Rules of
+Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #33:
+It never hurts to suck up to the boss.
+-- Rules of Acquisition (DS9 episode)
+%
+Ferengi Rule of Acquisition #34:
+War is good for business.
+-- Destiny (DS9 episode), The 34th Rule (DS9 novel)
+%
+Ferengi Rule of Acquisition #35:
+Peace is good for business.
+-- Destiny (DS9 episode), The 34th Rule (DS9 novel)
+%
+Ferengi Rule of Acquisition #37:
+The early investor reaps the most interest.
+-- Reservoir Ferengi (DS9 novella)
+%
+Ferengi Rule of Acquisition #39:
+Don't tell customers more than they need to know.
+-- Ascendance (DS9 novel)
+%
+Ferengi Rule of Acquisition #40:
+She can touch your lobes, but never your latinum.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #41:
+Profit is its own reward.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #43:
+Feed your greed, but not enough to choke it.
+-- The Buried Age (TNG novel)
+%
+Ferengi Rule of Acquisition #44:
+Never confuse wisdom with luck.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #45:
+Expand or die.
+-- Acquisition (ENT episode)
+%
+Ferengi Rule of Acquisition #47:
+Don't trust a man wearing a better suit than your own.
+-- Rivals (DS9 episode)
+%
+Ferengi Rule of Acquisition #48:
+The bigger the smile, the sharper the knife.
+-- Rules of Acquisition (DS9 episode)
+%
+Ferengi Rule of Acquisition #52:
+Never ask when you can take.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #53:
+Never trust anybody taller than you.
+-- Mission Gamma: Twilight (DS9 novel)
+%
+Ferengi Rule of Acquisition #54:
+Rate divided by time equals profit (also known as "The Velocity of Wealth").
+-- Typhon Pact: Raise the Dawn (DS9/TNG novel)
+%
+Ferengi Rule of Acquisition #55:
+Take joy from profit, and profit from joy.
+-- Worlds of Deep Space Nine: Bajor: Fragments and Omens (DS9 novel)
+%
+Ferengi Rule of Acquisition #57:
+Good customers are as rare as latinum - treasure them.
+-- Armageddon Game (DS9 episode)
+%
+Ferengi Rule of Acquisition #58:
+There is no substitute for success.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #59:
+Free advice is seldom cheap.
+-- Rules of Acquisition (DS9 episode)
+%
+Ferengi Rule of Acquisition #60:
+Keep your lies consistent.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #62:
+The riskier the road, the greater the profit.
+-- Rules of Acquisition (DS9 episode), Little Green Men (DS9 episode), Business
+As Usual (DS9 episode)
+%
+Ferengi Rule of Acquisition #63:
+Work is the best therapy - at least for your employees.
+-- Over a Torrent Sea (TTN novel)
+%
+Ferengi Rule of Acquisition #65:
+Win or lose, there's always Hupyrian beetle snuff.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #66:
+Someone's always got bigger ears.
+-- The Last Generation #3: What Happens Now (TNG comic)
+%
+Ferengi Rule of Acquisition #68:
+Risk doesn't always equal reward.
+-- Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #69:
+Ferengi are not responsible for the stupidity of other races.
+-- Balance of Power (TNG novel)
+%
+Ferengi Rule of Acquisition #74:
+Knowledge equals profit.
+-- Inside Man (VOY episode)
+%
+Ferengi Rule of Acquisition #75:
+Home is where the heart is - but the stars are made of latinum.
+-- Civil Defense (DS9 episode)
+%
+Ferengi Rule of Acquisition #76:
+Every once in a while, declare peace. It confuses the hell out of your enemies.
+-- The Homecoming (DS9 episode)
+%
+Ferengi Rule of Acquisition #77:
+If you break it, I'll charge you for it.
+-- Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #79:
+Beware of the Vulcan greed for knowledge.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #82:
+The flimsier the product, the higher the price.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #85:
+Never let the competition know what you're thinking.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #87:
+Learn the customer's weaknesses, so that you can better take advantage of him.
+-- Highest Score (DS9 novel)
+%
+Ferengi Rule of Acquisition #88:
+It ain't over till it’s over.
+-- Ferenginar: Satisfaction is Not Guaranteed (DS9 novella)
+%
+Ferengi Rule of Acquisition #88:
+Vengeance will cost you everything.
+-- The Poisoned Chalice (DS9 novel)
+%
+Ferengi Rule of Acquisition #89:
+Ask not what your profits can do for you, but what you can do for your profits.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #89:
+[It is] better to lose some profit and live than lose all profit and die.
+-- Strange New Worlds VI: Best Tools Available (DS9 short story)
+%
+Ferengi Rule of Acquisition #92:
+There are many paths to profit.
+-- Highest Score (DS9 novel)
+%
+Ferengi Rule of Acquisition #94:
+Females and finances don't mix.
+-- Ferengi Love Songs (DS9 episode), Profit and Lace (DS9 episode), The Ferengi
+Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #95:
+Expand or die.
+-- False Profits (VOY episode)
+%
+Ferengi Rule of Acquisition #97:
+Enough is never enough.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #98:
+Every man has his price.
+-- In the Pale Moonlight (DS9 episode)
+%
+Ferengi Rule of Acquisition #98:
+If you can't take it with you, don't go.
+-- I, Q (DS9 novel)
+%
+Ferengi Rule of Acquisition #99:
+Trust is the biggest liability of all.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #100:
+When it's good for business, tell the truth.
+-- Ascendance (DS9 novel)
+%
+Ferengi Rule of Acquisition #101:
+Profit trumps emotion.
+-- The Long Mirage (DS9 novel)
+%
+Ferengi Rule of Acquisition #102:
+Nature decays, but latinum lasts forever.
+-- The Jem'Hadar (DS9 episode)
+%
+Ferengi Rule of Acquisition #103:
+Sleep can interfere with opportunity.
+-- Rules of Acquisition (DS9 episode)
+%
+Ferengi Rule of Acquisition #104:
+Faith moves mountains - of inventory.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #106:
+There is no honor in poverty.
+-- Sacraments of Fire (DS9 novel)
+%
+Ferengi Rule of Acquisition #108:
+Hope doesn't keep the lights on.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #109:
+Dignity and an empty sack is worth the sack.
+-- Rivals (DS9 episode)
+%
+Ferengi Rule of Acquisition #111:
+Treat people in your debt like family - exploit them.
+-- Past Tense, Part I (DS9 episode)
+%
+Ferengi Rule of Acquisition #112:
+Never have sex with the boss' sister.
+-- Playing God (DS9 episode)
+%
+Ferengi Rule of Acquisition #113:
+Always have sex with the boss.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #117:
+You can't free a fish from water.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #121:
+Everything is for sale, even friendship.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #122:
+Never sleep with the bosses sister.
+-- Playing God (DS9 episode)
+%
+Ferengi Rule of Acquisition #123:
+Even a blind man can recognize the glow of latinum.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #125:
+You can't make a deal if you're dead.
+-- The Siege of AR-558 (DS9 episode)
+%
+Ferengi Rule of Acquisition #135:
+Listen to secrets, but never repeat them.
+-- Ascendance (DS9 novel)
+%
+Ferengi Rule of Acquisition #139:
+Wives serve, brothers inherit.
+-- Necessary Evil (DS9 episode)
+%
+Ferengi Rule of Acquisition #141:
+Only fools pay retail.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #144:
+There's nothing wrong with charity - as long as it winds up in your pocket.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #147:
+People love the bartender.
+-- Fearful Symmetry (DS9 novel)
+%
+Ferengi Rule of Acquisition #151:
+Even when you're a customer, sell yourself.
+-- The Long Mirage (DS9 novel)
+%
+Ferengi Rule of Acquisition #153:
+Sell the sizzle, not the steak.
+-- Deep Space Mine (DS9 comic)
+%
+Ferengi Rule of Acquisition #162:
+Even in the worst of times, someone turns a profit.
+-- The Ferengi Rules of Acquisition (DS9 reference book), Harbinger (DS9 video
+game)
+%
+Ferengi Rule of Acquisition #168:
+Whisper your way to success.
+-- Treachery, Faith, and the Great River (DS9 episode)
+%
+Ferengi Rule of Acquisition #177:
+Know your enemies, but do business with them always.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #181:
+Not even dishonesty can tarnish the shine of profit.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #183:
+When life hands you ungaberries, make detergent.
+-- Hollow Men (DS9 novel)
+%
+Ferengi Rule of Acquisition #184:
+A Ferengi waits to bid until his opponents have exhausted themselves.
+-- Balance of Power (TNG novel)
+%
+Ferengi Rule of Acquisition #188:
+Not even dishonesty can tarnish the shine of profit.
+-- Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #189:
+Let others keep their reputation. You keep their money.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #190:
+Hear all, trust nothing.
+-- Call to Arms (DS9 episode)
+%
+Ferengi Rule of Acquisition #192:
+Never cheat a Klingon - unless you're sure you can get away with it.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #193:
+Trouble comes in threes.
+-- Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #193:
+It's never too late to fire the staff.
+-- Cathedral (DS9 novel)
+%
+Ferengi Rule of Acquisition #194:
+It's always good business to know about new customers before they walk in your
+door.
+-- Whispers (DS9 episode)
+%
+Ferengi Rule of Acquisition #199:
+Location, location, location.
+-- The Soul Key (DS9 novel)
+%
+Ferengi Rule of Acquisition #200:
+A Ferengi chooses no side but his own.
+-- Ferenginar: Satisfaction is Not Guaranteed (DS9 novella)
+%
+Ferengi Rule of Acquisition #202:
+The justification for profit is profit.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #203:
+New customers are like razor-toothed gree worms. They can be succulent, but
+sometimes they bite back.
+-- Little Green Men (DS9 episode)
+%
+Ferengi Rule of Acquisition #208:
+Sometimes the only thing more dangerous than a question is an answer.
+-- Ferengi Love Songs (DS9 episode)
+%
+Ferengi Rule of Acquisition #211:
+Employees are the rungs on the ladder of success. Don't hesitate to step on
+them.
+-- Bar Association (DS9 episode)
+%
+Ferengi Rule of Acquisition #212:
+A good lie is easier to believe than the truth.
+-- Shattered (VOY episode), Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #214:
+Never begin a business negotiation on an empty stomach.
+-- The Maquis, Part I (DS9 episode)
+%
+Ferengi Rule of Acquisition #216:
+Never gamble with a telepath.
+-- The Laertian Gamble (DS9 novel)
+%
+Ferengi Rule of Acquisition #217:
+You can't free a fish from water.
+-- Past Tense, Part I (DS9 episode)
+%
+Ferengi Rule of Acquisition #218:
+Always know what you're buying.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #218:
+Sometimes what you get free costs entirely too much.
+-- Baby on Board (DS9 comic)
+%
+Ferengi Rule of Acquisition #219:
+Possession is eleven-tenths of the law.
+-- Balance of Power (TNG novel)
+%
+Ferengi Rule of Acquisition #223:
+Beware the man who doesn't take time for oo-mox.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #227:
+If that's what's written, then that's what's written.
+-- Favor the Bold (DS9 episode), Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #229:
+Latinum lasts longer than lust.
+-- Ferengi Love Songs (DS9 episode)
+%
+Ferengi Rule of Acquisition #235:
+Duck - death is tall.
+-- Mission Gamma: Twilight (DS9 novel)
+%
+Ferengi Rule of Acquisition #236:
+You can't buy fate.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #239:
+Never be afraid to mislabel a product.
+-- Body Parts (DS9 episode)
+%
+Ferengi Rule of Acquisition #240:
+Time, like latinum, is a highly limited commodity.
+-- Bar Association (DS9 episode), Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #242:
+More is good, all is better.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #243:
+Always leave yourself an out.
+-- Sacraments of Fire (DS9 novel)
+%
+Ferengi Rule of Acquisition #248:
+The definition of insanity is trying the same failed scheme and expecting
+different results.
+-- Department of Temporal Investigations: Shield of the Gods (DS9 novella)
+%
+Ferengi Rule of Acquisition #255:
+A wife is luxury, a smart accountant a necessity.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #261:
+A wealthy man can afford anything except a conscience.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #263:
+Never allow doubt to tarnish your lust for latinum.
+-- Bar Association (DS9 episode)
+%
+Ferengi Rule of Acquisition #266:
+When in doubt, lie.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #267:
+If you believe it, they believe it.
+-- Taking Wing (DS9 novel)
+%
+Ferengi Rule of Acquisition #272:
+Always inspect the merchandise before making a deal.
+-- The Abandoned (DS9 episode), Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition #280:
+If it ain't broke, don't fix it.
+-- Ferenginar: Satisfaction is Not Guaranteed (DS9 novella)
+%
+Ferengi Rule of Acquisition #284:
+Deep down, everyone's a Ferengi.
+-- The Ferengi Rules of Acquisition (DS9 reference book)
+%
+Ferengi Rule of Acquisition #285:
+No good deed ever goes unpunished.
+-- The Collaborator (DS9 episode), The Sound of Her Voice (DS9 episode)
+%
+Ferengi Rule of Acquisition #286 (inofficial):
+When Morn leaves, it's all over.
+-- The House of Quark (DS9 Episode)
+%
+Ferengi Rule of Acquisition #287:
+Always get somebody else to do the lifting.
+-- N-Vector (DS9 comic)
+%
+Ferengi Rule of Acquisition #288:
+Never get into anything that you can't get out of.
+-- N-Vector (DS9 comic)
+%
+Ferengi Rule of Acquisition #289:
+A man is only worth the sum of his possessions.
+-- Acquisition (ENT episode)
+%
+Ferengi Rule of Acquisition #290:
+An angry man is an enemy, and a satisfied man is an ally.
+-- Antimatter (DS9 novel)
+%
+Ferengi Rule of Acquisition #291:
+The less employees know about the cash flow, the smaller the share they can
+demand.
+-- Betrayal (DS9 novel)
+%
+Ferengi Rule of Acquisition #292:
+Only a fool passes up a business opportunity.
+-- Elite Force II (video game)
+%
+Ferengi Rule of Acquisition #293:
+The more time they take deciding, the more money they will spend.
+-- Stowaways (DS9 novel)
+%
+Ferengi Rule of Acquisition #294:
+A bargain usually isn't.
+-- The Pet (DS9 novel)
+%
+Ferengi Rule of Acquisition #299:
+Whenever you exploit someone, it never hurts to thank them. That way, it's
+easier to exploit them the next time.
+-- False Profits (VOY episode)
+%
+Ferengi Rule of Acquisition #431:
+When the shooting starts, let the mercenaries handle it.
+-- Star Trek Online (video game)
+%
+Ferengi Rule of Acquisition (inofficial):
+Exploitation begins at home.
+-- False Profits (VOY episode)
+%
+Ferengi Rule of Acquisition (inofficial, aka "The Unwritten Rule"):
+When no appropriate rule applies, make one up.
+-- False Profits (VOY episode)
+%
+Ferengi Rule of Acquisition (inofficial):
+When the messenger comes to appropriate your profits, kill the messenger.
+-- False Profits (VOY episode)
+%
+Ferengi Rule of Acquisition (inofficial):
+Money is money, but females are better.
+-- Life Support (DS9 episode)
+%
+Ferengi Rule of Acquisition (inofficial):
+Why ask, when you can take?
+-- Babel (DS9 episode)
+%
+Ferengi Rule of Acquisition (inofficial):
+Good things come in small packages.
+-- Move Along Home (DS9)
+%
+Ferengi Rule of Acquisition (inofficial):
+A distracted policeman is an opportunity.
+-- The Sound of Her Voice (DS9 episode)
 %

--- a/fortune-mod/datfiles/rules-of-acquisition
+++ b/fortune-mod/datfiles/rules-of-acquisition
@@ -109,7 +109,8 @@ Confidentiality equals profit.
 -- The Badlands, Part IV (DS9 novel)
 %
 Ferengi Rule of Acquisition #31:
-Never make fun of a Ferengi's mother - insult something he cares about instead.
+Never make fun of a Ferengi's mother - insult something he cares about
+instead.
 -- The Siege (DS9 episode), Elite Force II (video game), The Ferengi Rules of
 Acquisition (DS9 reference book)
 %
@@ -195,8 +196,8 @@ Keep your lies consistent.
 %
 Ferengi Rule of Acquisition #62:
 The riskier the road, the greater the profit.
--- Rules of Acquisition (DS9 episode), Little Green Men (DS9 episode), Business
-As Usual (DS9 episode)
+-- Rules of Acquisition (DS9 episode), Little Green Men (DS9 episode),
+Business As Usual (DS9 episode)
 %
 Ferengi Rule of Acquisition #63:
 Work is the best therapy - at least for your employees.
@@ -227,7 +228,8 @@ Home is where the heart is - but the stars are made of latinum.
 -- Civil Defense (DS9 episode)
 %
 Ferengi Rule of Acquisition #76:
-Every once in a while, declare peace. It confuses the hell out of your enemies.
+Every once in a while, declare peace. It confuses the hell out of your
+enemies.
 -- The Homecoming (DS9 episode)
 %
 Ferengi Rule of Acquisition #77:
@@ -259,7 +261,8 @@ Vengeance will cost you everything.
 -- The Poisoned Chalice (DS9 novel)
 %
 Ferengi Rule of Acquisition #89:
-Ask not what your profits can do for you, but what you can do for your profits.
+Ask not what your profits can do for you, but what you can do for your
+profits.
 -- The Ferengi Rules of Acquisition (DS9 reference book)
 %
 Ferengi Rule of Acquisition #89:
@@ -272,8 +275,8 @@ There are many paths to profit.
 %
 Ferengi Rule of Acquisition #94:
 Females and finances don't mix.
--- Ferengi Love Songs (DS9 episode), Profit and Lace (DS9 episode), The Ferengi
-Rules of Acquisition (DS9 reference book)
+-- Ferengi Love Songs (DS9 episode), Profit and Lace (DS9 episode), The
+Ferengi Rules of Acquisition (DS9 reference book)
 %
 Ferengi Rule of Acquisition #95:
 Expand or die.
@@ -389,8 +392,8 @@ Sell the sizzle, not the steak.
 %
 Ferengi Rule of Acquisition #162:
 Even in the worst of times, someone turns a profit.
--- The Ferengi Rules of Acquisition (DS9 reference book), Harbinger (DS9 video
-game)
+-- The Ferengi Rules of Acquisition (DS9 reference book), Harbinger (DS9
+video game)
 %
 Ferengi Rule of Acquisition #168:
 Whisper your way to success.
@@ -437,8 +440,8 @@ It's never too late to fire the staff.
 -- Cathedral (DS9 novel)
 %
 Ferengi Rule of Acquisition #194:
-It's always good business to know about new customers before they walk in your
-door.
+It's always good business to know about new customers before they walk in
+your door.
 -- Whispers (DS9 episode)
 %
 Ferengi Rule of Acquisition #199:


### PR DESCRIPTION
This pull request updates the already present _Ferengi Rules of Acquisition_ as discussed in issue #59.

The new revised set of rules is primarily based on these sources:
- https://memory-beta.fandom.com/wiki/Ferengi_Rules_of_Acquisition
- https://memory-alpha.fandom.com/wiki/Rules_of_Acquisition
- Worlds of Star Trek: Deep Space Nine - Volume 3: Ferenginar: Satisfaction is Not Guaranteed, p. 167-169 (DS9 novel)
- Star Trek Voyager Episode "False Profits" (S03E05)
- ... and many others for minor corrections

Notes:
- There are lots of rules missing. This is not an accident - AFAICT, there has never been an official, comprehensive list of all rules. There doesn't even seem to be a consensus regarding how many rules there actually are (i.e. what is the highest number)
- There are a couple of rules with the same number (e.g. rule 98, 218). Also not an accident, it seems some writers/authors did not check for collisions before making up a new rule :)
- All rules in the list are official/canon, meaning they actually appear in some form in Star Trek media (TV series, novels, comics etc.)
- The set includes a few 'inofficial' rules marked as such - those appear in Star Trek media (e.g. VOY "False Profits"), but there is no mention of a number and/or it is not clear if the rule actually is 'official' (as in sanctioned by the Ferengi government/society) or made up by certain Ferengi indiviuals

I put **a lot** of effort into this - much more than I wanted to :) I hope people like it!