### PR TITLE
Fix respecting LOCALDIR and COOKIEDIR

### DIFF
--- a/fortune-mod/datfiles/CMakeLists.txt
+++ b/fortune-mod/datfiles/CMakeLists.txt
@@ -68,7 +68,7 @@ ADD_CUSTOM_TARGET(
 )
 INSTALL(
     FILES ${_install_unrot_cookies}
-    DESTINATION "${LOCALDIR}"
+    DESTINATION "${COOKIEDIR}"
 )
 
 IF (NOT NO_OFFENSIVE)

--- a/fortune-mod/datfiles/off/CMakeLists.txt
+++ b/fortune-mod/datfiles/off/CMakeLists.txt
@@ -54,5 +54,5 @@ ADD_CUSTOM_TARGET(
 )
 INSTALL(
     FILES ${_install_rotated_cookies}
-    DESTINATION "${LOCALODIR}"
+    DESTINATION "${OCOOKIEDIR}"
 )


### PR DESCRIPTION
The intention of LOCALDIR seems to be to allow local cookies to be
provided by the sysadmin in e.g. /usr/local/share/fortune,
but if set, before this patch, even cookies distributed
by upstream were stored there (and nothing in COOKIEDIR, e.g.
/usr/share/fortune - https://bugs.gentoo.org/865809).

Originally, we were setting LOCALDIR=COOKIEDIR=/usr/share/fortune to
workaround the issue, but see https://bugs.gentoo.org/857246.

Signed-off-by: Sam James <sam@gentoo.org>