### PR TITLE
Support for finding fortune files from XDG_DATA_DIRS

### DIFF
--- a/fortune-mod/fortune/fortune.c
+++ b/fortune-mod/fortune/fortune.c
@@ -435,21 +435,6 @@ static FILEDESC *new_fp(void)
     return fp;
 }
 
-#ifdef MYDEBUG
-static inline void debugprint(const char *msg, ...)
-{
-    va_list ap;
-
-    va_start(ap, msg);
-    vfprintf(stderr, msg, ap);
-    fflush(stderr);
-    va_end(ap);
-}
-#else
-#define debugprint(format, ...)                                                \
-    {                                                                          \
-    }
-#endif
 /*
  * is_dir:
  *      Return true if the file is a directory, false otherwise.
@@ -460,11 +445,11 @@ static int is_dir(const char *const file)
 
     if (stat(file, &sbuf) < 0)
     {
-        debugprint("is_dir failed for file=<%s>\n", file);
+        DPRINTF(1, (stderr, "is_dir failed for file=<%s>\n", file));
         return -1;
     }
     const bool ret = (S_ISDIR(sbuf.st_mode) ? true : false);
-    debugprint("is_dir for file=<%s> gave ret=<%d>\n", file, ret);
+    DPRINTF(1, (stderr, "is_dir for file=<%s> gave ret=<%d>\n", file, ret));
     return ret;
 }
 
@@ -620,8 +605,8 @@ static int add_file(int percent, const char *file, const char *dir,
             ((fd = open4read(path)) < 0)) ||
         !path_is_absolute(path))
     {
-        debugprint("check file fd=%d path=<%s> dir=<%s> file=<%s> percent=%d\n",
-            fd, path, dir, file, percent);
+        DPRINTF(2, (stderr, "check file fd=%d path=<%s> dir=<%s> file=<%s> percent=%d\n",
+            fd, path, dir, file, percent));
         bool found = false;
         if (!dir && (!strchr(file, '/')))
         {


### PR DESCRIPTION
Resolves #74.

This reworks support for FORTDIR/OFFDIR and LOCFORTDIR/LOCOFFDIR to support any amount of directories. I've also refactored the fortune file lookup logic to be more sensible.

---

My intention for the new lookup logic is as follows:

- If the name starts with `/` or `./` or `../`, then treat it as absolute/relative to current directory. Don't do any further processing.
- If the name ends with `-o`, strip that suffix and look in offensive dirs instead of regular fortune dirs. This matches the BSD-compatibility feature.
- For each fortune directory `<fortdir>` (out of paths in `$XDG_DATA_DIR`, FORTDIR, and LOCFORTDIR, or the corresponding offensive dirs):
  - For each language `<lang>`, try `<fortdir>/<lang>/<name>`, then try `<fortdir>/<name>`
  - Take the first one that's found, don't use all found paths.
- If still no fortune is found, try using the original name as a path relative to the current directory.

Does this look ok?

---

Remaining work:
- [ ] Localisation support
- [ ] Move XDGFORTDIR and XDGOFFDIR to CMake
- [ ] Support for probabilities for the `all` argument e.g. `fortune 9% all`