### PR TITLE
Fix BSD-style -o suffix

### DIFF
--- a/fortune-mod/fortune/fortune.c
+++ b/fortune-mod/fortune/fortune.c
@@ -623,40 +623,6 @@ static int add_file(int percent, const char *file, const char *dir,
         debugprint("check file fd=%d path=<%s> dir=<%s> file=<%s> percent=%d\n",
             fd, path, dir, file, percent);
         bool found = false;
-        if (!dir && (!strchr(file, '/')))
-        {
-            if (((sp = strrchr(file, '-')) != NULL) && (strcmp(sp, "-o") == 0))
-            {
-#define CALL__add_file(dir) add_file(percent, file, dir, head, tail, parent)
-#define COND_CALL__add_file(loc_dir, dir)                                      \
-    ((!strcmp((loc_dir), (dir))) ? 0 : CALL__add_file(dir))
-                /* BSD-style '-o' offensive file suffix */
-                *sp = '\0';
-                found = CALL__add_file(LOCOFFDIR) ||
-                        COND_CALL__add_file(LOCOFFDIR, OFFDIR);
-                /* put the suffix back in for better identification later */
-                *sp = '-';
-            }
-            else if (All_forts)
-            {
-                found =
-                    (CALL__add_file(LOCFORTDIR) || CALL__add_file(LOCOFFDIR) ||
-                        COND_CALL__add_file(LOCFORTDIR, FORTDIR) ||
-                        COND_CALL__add_file(LOCOFFDIR, OFFDIR));
-            }
-            else if (Offend)
-            {
-                found = (CALL__add_file(LOCOFFDIR) ||
-                         COND_CALL__add_file(LOCOFFDIR, OFFDIR));
-            }
-            else
-            {
-                found = (CALL__add_file(LOCFORTDIR) ||
-                         COND_CALL__add_file(LOCFORTDIR, FORTDIR));
-            }
-#undef COND_CALL__add_file
-#undef CALL__add_file
-        }
         if (!found && !parent && !dir)
         { /* don't display an error when trying language specific files */
             if (env_lang)


### PR DESCRIPTION
This fixes this feature that is documented in the manual:

> A plain name (i.e., not a path to a file or directory) that ends in “-o” will be assumed to be an offensive database, and will have its suffix stripped off and be searched in the offensive directory (even if the neither of the -a or -o options were specified).

An example of this is running `fortune 90% politics 10% politics-o`, which produces unoffensive political fortunes 90% of the time and offensive ones 10% of the time. Also supported is the special argument `all-o`, which corresponds to all offensive fortunes, so you can do e.g. `fortune 90% all 10% all-o`.

The existing code to handle `*-o` was quite broken and didn't run when it should. This change removes that and reimplements it in form_file_list(), which also avoids some duplication regarding how OFFDIR/LOCOFFDIR are used.