### PR TITLE
Fix functionality on Windows

### DIFF
--- a/fortune-mod/util/rot.c
+++ b/fortune-mod/util/rot.c
@@ -3,8 +3,19 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 int main(void)
 {
+#ifdef _WIN32
+    // Force binary mode to avoid CRLF translation.
+    setmode(_fileno(stdin), _O_BINARY);
+    setmode(_fileno(stdout), _O_BINARY);
+#endif
+
     int a;
     while ((a = getchar()) != EOF)
     {

--- a/fortune-mod/util/strfile.c
+++ b/fortune-mod/util/strfile.c
@@ -371,13 +371,13 @@ int main(int argc, char **argv)
     bool len_was_set = false;
 
     getargs(argc, argv); /* evalute arguments */
-    if (!(inf = fopen(input_filename, "r")))
+    if (!(inf = fopen(input_filename, "rb")))
     {
         perror(input_filename);
         exit(1);
     }
 
-    if (!(outf = fopen(output_filename, "w")))
+    if (!(outf = fopen(output_filename, "wb")))
     {
         perror(output_filename);
         exit(1);


### PR DESCRIPTION
The binary on Windows fails to actually print fortunes.

Root caused, fixed and tested in this pull request.

Essentially on Windows, file I/O should be done in binary mode to avoid CRLF pitfalls.

---

Instructions to build on MINGW64 follow since the `windows-x64.yml` is exceedingly indirect. Note, the Perl CPAN dependencies work improperly inside MINGW64 environment. It is easiest to remove the parts that call Perl from the CMake build file (mostly documentation and testing). However, included a way to make it below for reference.

Set up prerequisites in a fresh MINGW64 installation:

```bash
pacman --noconfirm -Syuu
pacman --noconfirm -S base-devel git mingw-w64-x86_64-gcc mingw-w64-x86_64-make mingw-w64-x86_64-cmake mingw-w64-x86_64-perl mingw-w64-x86_64-pcre2 mingw-w64-x86_64-docbook-xsl mingw-w64-x86_64-recode
/path/to/strawberry/perl/bin/cpanm -n App::Docmake Code::TidyAll::Plugin::ClangFormat Code::TidyAll::Plugin::Flake8 Code::TidyAll::Plugin::TestCount File::Find::Object List::Util Path::Tiny Perl::Critic Perl::Tidy Test::Code::TidyAll Test::Differences Test::RunValgrind Test::TrailingSpace Test::Trap
cd /path/to/fortune-mod/ && rm -rf build/ && mkdir build/ && cd build/
```

Build using Makefiles (slow) and Windows' regular expressions:

```bash
cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DTARGET_ARCH=x86_64-w64-mingw32 -DCMAKE_PREFIX_PATH=C:/Games/Fortune -DCMAKE_INSTALL_PREFIX=C:/Games/Fortune -DUSE_WIN32_REGEX_LIBS=ON ../fortune-mod
make && make install
```

Build using Ninja (fast) and PCRE2:

```bash
cmake -DCMAKE_BUILD_TYPE=Release -DTARGET_ARCH=x86_64-w64-mingw32 -DCMAKE_PREFIX_PATH=D:/Games/Fortune -DCMAKE_INSTALL_PREFIX=C:/Games/Fortune -DUSE_PCRE=ON ../fortune-mod
cmake --build . --clean-first && cmake --install .
```

Fix symbolic links using PowerShell:

```pwsh
Get-ChildItem -Path . -Recurse -File | Where-Object { $_.Extension -ne ".dat" } | ForEach-Object {
    $target = $_.BaseName
    $linkPath = Join-Path $_.DirectoryName ($_.BaseName + ".u8")

    # Remove existing symlink if it exists
    if (Test-Path $linkPath) {
        Remove-Item $linkPath -Force
    }

    # Create symbolic link
    New-Item -ItemType SymbolicLink -Path $linkPath -Target $target
    Write-Host "Created symlink: $linkPath -> $target"
}
```

Enable proper UTF-8 behavior when calling Fortune in PowerShell:

```powershell
[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false) # add to profile, if desired
&"C:\Games\Fortune\games\fortune.exe" | Write-Host
```