### PR TITLE
Manual pages: document restrictions in paths on the command line

### DIFF
--- a/fortune-mod/fortune/gen-fortune-docbook-page.pl
+++ b/fortune-mod/fortune/gen-fortune-docbook-page.pl
@@ -471,6 +471,11 @@ EOF
 $out->print(<<'END_OF_STRING');
 
 </para>
+<para>
+When passing files to fortune, directories must be specified by absolute
+pathnames, and filenames starting with a dot are ignored. See:
+http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=241888
+</para>
 
 </refsect1>
 


### PR DESCRIPTION
Bug-Debian: http://bugs.debian.org/241888